### PR TITLE
🔀 (#13) SwiftLint 규칙 수정 및 규칙에 맞게 코드 수정

### DIFF
--- a/GSPASS/.swiftlint.yml
+++ b/GSPASS/.swiftlint.yml
@@ -1,3 +1,6 @@
+disabled_rules:
+  - identifier_name
+
 excluded:
   - Pods
   - GSPASS/AppDelegate.swift

--- a/GSPASS/GSPASS/Model/Network/GSPASSAPI.swift
+++ b/GSPASS/GSPASS/Model/Network/GSPASSAPI.swift
@@ -18,12 +18,12 @@ enum GSPASSAPI {
 }
 
 extension GSPASSAPI {
-    
+
     public var uri: String {
         let baseUrl = "http://13.125.161.204:8080"
         return baseUrl + path
     }
-    
+
     public var method: HTTPMethod {
         switch self {
         case .register,
@@ -34,7 +34,7 @@ extension GSPASSAPI {
             return .get
         }
     }
-    
+
     public var parameters: Parameters? {
         switch self {
         case .register(let registerModel):
@@ -50,7 +50,7 @@ extension GSPASSAPI {
             return nil
         }
     }
-    
+
     public var encoding: ParameterEncoding {
         switch self.method {
         case .get:
@@ -59,7 +59,7 @@ extension GSPASSAPI {
             return JSONEncoding.default
         }
     }
-    
+
     public var header: HTTPHeaders? {
         switch self {
         case .register,
@@ -69,7 +69,7 @@ extension GSPASSAPI {
             return nil
         }
     }
-    
+
     private var path: String {
         switch self {
         case .register:
@@ -82,17 +82,17 @@ extension GSPASSAPI {
             return "/overlap"
         }
     }
-    
+
     private var accessTocken: String {
         let keychain = KeychainSwift()
         return keychain.get("ACCESS-TOKEN") ?? ""
     }
-    
+
     private var refreshToken: String {
         let keychain = KeychainSwift()
         return keychain.get("REFRESH-TOKEN") ?? ""
     }
-    
+
     private func encodingQuery(query: String) -> String {
         return query.addingPercentEncoding(withAllowedCharacters: .urlFragmentAllowed) ?? query
     }

--- a/GSPASS/GSPASS/Model/Network/HTTPClient.swift
+++ b/GSPASS/GSPASS/Model/Network/HTTPClient.swift
@@ -12,7 +12,7 @@ import RxAlamofire
 
 class HTTPClient {
     static let shared = HTTPClient()
-    
+
     func networking<T: Codable>(_ api: GSPASSAPI, _ networkModel: T.Type) -> Observable<T> {
         requestData(api.method, api.uri,
                     parameters: api.parameters,


### PR DESCRIPTION
swiftlint의 규칙중 언더바(_)사용을 막던 'identifier_name'을 검사할 규칙에서 제외 시켰고, swiftlint가 띄우던 노란줄을 코드 수정으로 없에는 작업을 하였습니다.